### PR TITLE
UnicodeEncodeError fix

### DIFF
--- a/fetch-greader.py
+++ b/fetch-greader.py
@@ -80,7 +80,7 @@ def main():
         # enumerate feeds
         print "* Please specify feed number (-f, --feed) to fetch: *"
         for i, feed in enumerate(reader.getSubscriptionList()):
-            print "[%d] %s" % (i, feed.title)
+            print "[%d]" % (i), feed.title.encode('utf-8')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixed a bug that occurred when printing a feed's title that contained Unicode chars:

"UnicodeEncodeError: 'ascii' codec can't encode character.."
